### PR TITLE
Adding devcontainers for search-futures

### DIFF
--- a/search-futures-compose/.devcontainer/.env
+++ b/search-futures-compose/.devcontainer/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROFILES="server,database"

--- a/search-futures-compose/.devcontainer/Dockerfile
+++ b/search-futures-compose/.devcontainer/Dockerfile
@@ -1,0 +1,69 @@
+FROM mcr.microsoft.com/devcontainers/anaconda:0-3
+
+ARG SERVER=true
+# ARG ESGF_VERSION
+# ARG PYSTAC_VERSION
+# ARG PYSTAC_CLIENT_VERSION
+# ARG STAC_FASTAPI_ELASTICSEARCH_VERSION
+
+RUN mkdir -p /workspaces
+# Install ESGF-STAC-client
+RUN cd /workspaces/ \
+    && git clone https://github.com/cedadev/esgf-stac-client \
+    && cd esgf-stac-client/ \
+    && pip install -r requirements.txt \
+    && pip install -r requirements_dev.txt \
+    && pip install -e . --no-deps
+# Mark repo as safe
+RUN git config --system --add safe.directory /workspaces/esgf-stac-client
+# Change directory ownership
+RUN chown -R vscode:vscode /workspaces/esgf-stac-client
+
+# Install Pystac
+RUN cd /workspaces/ \
+    && git clone -b asset-search https://github.com/cedadev/pystac \
+    && cd pystac/ \
+    && pip install -r requirements-dev.txt \
+    && pip install -e . --no-deps
+# Mark repo as safe
+RUN git config --system --add safe.directory /workspaces/pystac
+# Change directory ownership
+RUN chown -R vscode:vscode /workspaces/pystac
+
+# Install Pystac-client
+RUN cd /workspaces/ \
+    && git clone -b asset-search https://github.com/cedadev/pystac-client \
+    && cd pystac-client/ \
+    && perl -p -i -w -e 's/^pystac==1.4.0/#pystac==1.4.0/g' requirements-min.txt \
+    && pip install -r requirements-min.txt \
+    && pip install -r requirements-dev.txt \
+    && pip install -e . --no-deps
+# Mark repo as safe
+RUN git config --system --add safe.directory /workspaces/pystac-client
+# Change directory ownership
+RUN chown -R vscode:vscode /workspaces/pystac-client
+
+
+#Install stac-fastapi-elasticsearch
+RUN if [$SERVER="true"] ; then \
+RUN    cd /workspaces/ \
+    && git clone -b atod https://github.com/cedadev/stac-fastapi-elasticsearch \
+    && cd stac-fastapi-elasticsearch/ \
+    && pip install -r requirements.txt \
+    && pip install django-flexi-settings==0.1.1 \
+    && pip install -e .[server,dev] \
+    # Mark repo as safe
+    && git config --system --add safe.directory /workspaces/stac-fastapi-elasticsearch \
+    # Change directory ownership
+    && chown -R vscode:vscode /workspaces/stac-fastapi-elasticsearch
+# ; fi
+
+RUN if ["true" = "true"]; then echo 'RUNNING TRUE' ; fi
+
+RUN if ["true" = "true"]; then echo 'RUNNING TRUE' ; fi
+
+
+# # COPY settings.py /workspaces/stac-fastapi-elasticsearch/stac_fastapi/elasticsearch/settings.py
+
+# # Update packages so unit tests work in container
+RUN pip install --upgrade pip pyopenssl

--- a/search-futures-compose/.devcontainer/devcontainer.json
+++ b/search-futures-compose/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
+{
+    "name": "Anaconda (Python 3)",
+    // "build": {
+    //     "context": "..",
+    //     "dockerfile": "Dockerfile"
+    // },
+    "workspaceFolder": "/workspaces",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "bash esgf-stac-client/.devcontainer/postCreateCommand.sh",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Configure tool-specific properties.
+    // "customizations": {},
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root",
+    "dockerComposeFile": "./docker-compose.yml",
+    "service": "app-elasticsearch",
+    "shutdownAction": "stopCompose"
+}

--- a/search-futures-compose/.devcontainer/docker-compose.yml
+++ b/search-futures-compose/.devcontainer/docker-compose.yml
@@ -1,0 +1,54 @@
+version: "3.8"
+
+services:
+  app-elasticsearch:
+    container_name: stac-fastapi-elasticsearch
+    image: cedadev/stac-fastapi-elasticsearch
+    profiles:
+      - server
+    working_dir: /workspaces/stac-fastapi-elasticsearch
+    build:
+      context: .
+      dockerfile: Dockerfile
+      # args:
+      #   SERVER: "true"
+    environment:
+      - STAC_ELASTICSEARCH_SETTINGS=flexi_settings.settings
+      - DJANGO_FLEXI_SETTINGS_ROOT=/workspaces/stac-fastapi-elasticsearch/conf/settings.py
+      - APP_HOST=0.0.0.0
+      - APP_PORT=8081
+
+    ports:
+      - 8081:8081
+    volumes:
+      - ..:/workspaces/.devcontainer:cached
+    depends_on:
+      - database
+    command: bash -c "/workspaces/stac-fastapi-elasticsearch/scripts/wait-for-it.sh database:9200 -t 60 && python -m stac_fastapi.elasticsearch.run"
+  database:
+    container_name: stac-elasticsearch
+    profiles:
+      - database
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.2
+    environment:
+      - node.name=es01
+      - cluster.name=stac-cluster
+      - discovery.type=single-node
+      - network.host=0.0.0.0
+      - http.port=9200
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+      - DATABASE=true
+    ports:
+      - 9200:9200
+  loadsample-elasticsearch:
+    image: cedadev/stac-fastapi-elasticsearch
+    profiles:
+      - database
+    command: bash -c "/workspaces/stac-fastapi-elasticsearch/scripts/wait-for-it.sh database:9200 -t 60 && python /workspaces/stac-fastapi-elasticsearch/scripts/ingest_test_data.py --host http://database:9200"
+    depends_on:
+      - database
+      - app-elasticsearch
+
+networks:
+  default:
+    name: stac-fastapi-elasticsearch-network

--- a/search-futures/.devcontainer/Dockerfile
+++ b/search-futures/.devcontainer/Dockerfile
@@ -1,0 +1,107 @@
+FROM mcr.microsoft.com/devcontainers/anaconda:0-3
+
+# Copy environment.yml (if found) to a temp location so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then \
+    umask 0002 && \
+    /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml ; \
+    fi && \
+    rm -rf /tmp/conda-tmp
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# Include a custom entrypoint that will execute startup services
+# COPY .devcontainer/docker-entrypoint.sh /usr/local/bin/
+
+ENV DATABASE=1
+ENV SERVER=1
+ENV PYSTAC=1
+ENV PYSTAC_CLIENT=1
+ENV ESGF_CLIENT=1
+
+ARG ELK_VERSION=7.17.4
+ARG STAC_FASTAPI_ELASTICSEARCH_VERSION=atod
+ARG PYSTAC_VERSION=asset-search
+ARG PYSTAC_CLIENT_VERSION=asset-search
+ARG ESGF_CLIENT_VERSION=master
+
+RUN mkdir /workspaces
+
+# Install elasticsearch database
+RUN if [ "$DATABASE" = "1" ] ; then \
+    mkdir /elastic && \
+    # Download the elasticsearch code archive
+    curl -fsSL -o elasticsearch.tar.gz https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELK_VERSION-linux-x86_64.tar.gz && \
+    curl -fsSL -o elasticsearch.tar.gz.sha https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-$ELK_VERSION-linux-x86_64.tar.gz.sha512 && \
+    # Check checksum
+    echo "$(awk '{print $1}'  elasticsearch.tar.gz.sha)  elasticsearch.tar.gz" > elasticsearch.tar.gz.sha && \
+    shasum -a 512 -c elasticsearch.tar.gz.sha && \
+    tar -xf elasticsearch.tar.gz  && \
+    cp -r elasticsearch-$ELK_VERSION/* /elastic/. && \
+    rm -rf elasticsearch* && \
+    chown -R vscode:vscode /elastic ; \
+    fi
+
+# Install stac-fastapi-elasticsearch
+RUN if [ "$SERVER" = "1" ] ; then \
+    cd /workspaces/ && \
+    git clone -b $STAC_FASTAPI_ELASTICSEARCH_VERSION https://github.com/cedadev/stac-fastapi-elasticsearch && \
+    cd stac-fastapi-elasticsearch/ && \
+    pip install -r requirements.txt && \
+    pip install django-flexi-settings==0.1.1 && \
+    pip install -e .[server,dev] && \
+    # Mark repo as safe
+    git config --system --add safe.directory /workspaces/stac-fastapi-elasticsearch && \
+    # Change directory ownership
+    chown -R vscode:vscode /workspaces/stac-fastapi-elasticsearch ; \
+    fi
+
+# Install Pystac
+RUN if [ "$PYSTAC" = "1" ] ; then \
+    cd /workspaces/ && \
+    git clone -b $PYSTAC_VERSION https://github.com/cedadev/pystac && \
+    cd pystac/ && \
+    pip install -r requirements-dev.txt && \
+    pip install -e . --no-deps && \
+    # Mark repo as safe
+    git config --system --add safe.directory /workspaces/pystac && \
+    # Change directory ownership
+    chown -R vscode:vscode /workspaces/pystac ; \
+    fi
+
+# Install Pystac-client
+RUN if [ "$PYSTAC_CLIENT" = "1" ] ; then \
+    cd /workspaces/ && \
+    git clone -b $PYSTAC_CLIENT_VERSION https://github.com/cedadev/pystac-client && \
+    cd pystac-client/ && \
+    perl -p -i -w -e 's/^pystac==1.4.0/#pystac==1.4.0/g' requirements-min.txt && \
+    pip install -r requirements-min.txt && \
+    pip install -r requirements-dev.txt && \
+    pip install -e . --no-deps  && \
+    # Mark repo as safe
+    git config --system --add safe.directory /workspaces/pystac-client && \
+    # Change directory ownership
+    chown -R vscode:vscode /workspaces/pystac-client ; \
+    fi
+
+#Install stac-fastapi-elasticsearch
+RUN if [ "$ESGF_CLIENT" = "1" ] ; then \
+    cd /workspaces/ && \
+    git clone -b $ESGF_CLIENT_VERSION https://github.com/cedadev/esgf-stac-client && \
+    cd esgf-stac-client/ && \
+    pip install -r requirements.txt && \
+    pip install -r requirements_dev.txt && \
+    pip install -e . && \
+    # Mark repo as safe
+    git config --system --add safe.directory /workspaces/esgf-stac-client && \
+    # Change directory ownership
+    chown -R vscode:vscode /workspaces/esgf-stac-client ; \
+    fi
+
+# Update packages so unit tests work in container
+RUN pip install --upgrade pip pyopenssl
+
+EXPOSE 9200

--- a/search-futures/.devcontainer/conf/fastapi_settings.py
+++ b/search-futures/.devcontainer/conf/fastapi_settings.py
@@ -1,0 +1,33 @@
+# encoding: utf-8
+"""
+
+"""
+__author__ = "Rhys Evans"
+__date__ = "24 Jan 2023"
+__copyright__ = "Copyright 2018 United Kingdom Research and Innovation"
+__license__ = "BSD - see LICENSE file in top-level package directory"
+__contact__ = "rhys.r.evans@stfc.ac.uk"
+
+import os
+
+ELASTICSEARCH_CONNECTION = {
+    "hosts": ["locahost:9200"],
+    "verify_certs": False,
+    "ssl_show_warn": False,
+}
+
+COLLECTION_INDEX = "stac-collections"
+ITEM_INDEX = "stac-items"
+ASSET_INDEX = "stac-assets"
+
+STAC_DESCRIPTION = "CEDA STAC API"
+STAC_TITLE = "CEDA STAC API"
+
+APP_HOST = os.environ.get("APP_HOST", "0.0.0.0")
+APP_PORT = int(os.environ.get("APP_PORT", 8080))
+
+enable_response_models = True
+openapi_url = "/api"
+docs_url = "/docs"
+
+posix_download_url = "https://data.ceda.ac.uk"

--- a/search-futures/.devcontainer/devcontainer.json
+++ b/search-futures/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
+{
+    "name": "Anaconda (Python 3)",
+    "build": {
+        "context": "..",
+        "dockerfile": "Dockerfile"
+    },
+    "workspaceFolder": "/workspaces",
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+    // Configure tool-specific properties.
+    // "customizations": {},
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+    "postStartCommand": "bash devcontainers/search-futures/.devcontainer/postCreateCommand.sh"
+}

--- a/search-futures/.devcontainer/noop.txt
+++ b/search-futures/.devcontainer/noop.txt
@@ -1,0 +1,36 @@
+# Download the kibana code archive
+# RUN curl -fsSL -o kibana.tar.gz https://artifacts.elastic.co/downloads/kibana/kibana-$ELK_VERSION-linux-x86_64.tar.gz
+
+# RUN curl -fsSL -o kibana.tar.gz.sha https://artifacts.elastic.co/downloads/kibana/kibana-$ELK_VERSION-linux-x86_64.tar.gz.sha512
+
+# # RUN shasum -a 512 -c kibana.tar.gz.sha
+
+# # RUN echo "$(cat kibana.tar.gz.sha) *kibana.tar.gz" | sha512sum --check -
+
+# RUN tar -xf kibana.tar.gz
+
+# # Create a user to run kibana
+# ENV KIBANA_UID 1001
+# ENV KIBANA_USER kibana
+# ENV KIBANA_HOME /home/$KIBANA_USER
+# RUN useradd \
+#     --uid $KIBANA_UID \
+#     --user-group \
+#     --create-home \
+#     --home-dir $KIBANA_HOME \
+#     --shell /sbin/nologin \
+#     $KIBANA_USER
+
+# # Copy files and cleanup
+# RUN cp -r kibana-$ELK_VERSION-linux-x86_64/* $KIBANA_HOME/. && \
+#     rm -rf kibana*
+
+# Copy elasticsearch root CA and configuration file
+# COPY conf/* $KIBANA_HOME/config/
+
+# Change ownership of directory
+# RUN chown -R $KIBANA_USER:$KIBANA_USER $KIBANA_HOME
+
+# USER $KIBANA_UID
+
+# CMD ["./home/kibana/bin/kibana"]

--- a/search-futures/.devcontainer/postCreateCommand.sh
+++ b/search-futures/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+echo "DOCK ENTRYPOINT STARTED as $USER"
+
+if [ "$DATABASE" = "1" ] ; then
+    echo "STARTING ELASTICSEARCH"
+    /elastic/bin/elasticsearch -d -p /elastic/pid
+    stac-fastapi-elasticsearch/scripts/wait-for-it.sh localhost:9200 -t 120
+fi
+
+if [ "$DATABASE" = "1" ] && [ "$SERVER" = "1" ] ; then
+    echo "INGESTING DATA"
+    python stac-fastapi-elasticsearch/scripts/ingest_test_data.py --host localhost:9200
+fi
+
+if [ "$SERVER" = "1" ] ; then
+    echo "STARTING FASTAPI SERVER"
+    cp devcontainers/search-futures/.devcontainer/conf/fastapi_settings.py stac-fastapi-elasticsearch/stac_fastapi/elasticsearch/settings.py
+    cd stac-fastapi-elasticsearch
+    export STAC_ELASTICSEARCH_SETTINGS=stac_fastapi.elasticsearch.settings
+    python -m stac_fastapi.elasticsearch.run
+fi


### PR DESCRIPTION
One downside of this method I've noticed is that if you make changes to a repo and then rebuild the changes will be lost unless you push to github.

You could use a script to install them locally then let the devcontainer mount them.

Also having all the devcontainers in one repo could get messy. Could we make a separate organisation `cedadev-devcontainers` each devcontainer could then have it's own repo with the same name as the code repo.